### PR TITLE
Part of session parameters (testDuration concurrentUsers numOfWorkers) are customizable from frontend now

### DIFF
--- a/client/pages/Sessions/tabs/RunTab.jsx
+++ b/client/pages/Sessions/tabs/RunTab.jsx
@@ -4,11 +4,6 @@ import { useDispatch, useSelector } from "react-redux";
 import { setDemoData, setRunTabData } from "../../../redux/dataSlice";
 import { useParams, useNavigate } from 'react-router-dom';
 
-const f = async () => {
-  const result = await window.electronAPI.kaskadestart();
-  console.log(result)
-  store.dispatch(setDemoData(result));
-}
 
 const RunTab = () => {
   const dispatch = useDispatch();
@@ -37,13 +32,13 @@ const RunTab = () => {
     } else {
       updatedConfigCopy[inputName] = parseInt(inputValue);
     }
-
+    console.log(updatedConfigCopy)
     setUpdatedConfig(updatedConfigCopy);
   };
 
   // console.log("updatedConfig: ", updatedConfig)
 
-  const handleRunButton = () =>{
+  const handleRunButton = async () =>{
     //primative check to make sure the user filled out the config inputs. handler function will not execute 
     //if user doesn't fill out expected parameters
     if (
@@ -53,10 +48,11 @@ const RunTab = () => {
       ) {
         return;
       }
-      
-      
-      //updatedConfig state is an object that should be able to be passed as our existing configFile format
     console.log("updatedConfig to pass to core logic: ", updatedConfig)
+    const result = await window.electronAPI.kaskadestart(updatedConfig);
+    console.log(result)
+    store.dispatch(setDemoData(result));
+      //updatedConfig state is an object that should be able to be passed as our existing configFile format
   }
 
 
@@ -113,9 +109,8 @@ const RunTab = () => {
         </label>
         <br />
       </form>
-        <button type="button" onClick={f}>Run</button>
 
-        {/* <button type="button" onClick={handleRunButton}>Run</button> */}
+        <button type="button" onClick={handleRunButton}>Run</button>
         <button onClick={() => { navigate("/result/" + sessionId + "/" + 1660926192826 )}}>Result</button>
     </div>
   );

--- a/core/runner.js
+++ b/core/runner.js
@@ -40,7 +40,7 @@ function runnerCb(config, resultCb) {
         }
         // 3. send one request
         metrics.beforeSendRequest(sessionId, requestId);
-        httpClient.makeRequest(config.sessions[sessionId].requests[requestId], onResponse, onError);  
+        httpClient.makeRequest(config.requests[requestId], onResponse, onError);  
     }
 
     function onResponse(data) {
@@ -49,7 +49,7 @@ function runnerCb(config, resultCb) {
         // 5. send to the next request
         requestId ++;
         // check if this session ends; if so, start a new session
-        if (requestId >= config.sessions[sessionId].requests.length) {
+        if (requestId >= config.requests.length) {
             requestId = 0;
             // to-do: support multiple sessions for stretch
         }

--- a/core/validateOpts.js
+++ b/core/validateOpts.js
@@ -6,9 +6,9 @@ function validateOpts(opts){
     (opts.servers !== undefined 
     && opts.testDuration !== undefined
     && opts.concurrentUsers !== undefined
-    && opts.sessions !== undefined);
-  
-  if(required_opts_available){
+    && opts.requests !== undefined &&
+    opts.numOfWorkers !== undefined)
+    if(required_opts_available){
 
     // helper functions
     const isValidUrl = urlString => {
@@ -44,25 +44,26 @@ function validateOpts(opts){
       }
     };
     
-    const isValidSession = session => {
-      const { sessionName, requests } = session;
-      if(!sessionName || !requests){
-        throw new Error('sessionName or requests missing');
-      }
-      else{
-        if(!Array.isArray(requests) || requests.length < 1 || typeof sessionName !== 'string'){
-          throw new Error('Possible error: \n0.requests is not an array\n1.requests is an empty array\n2.sessionName is not a string');
-        }
-        else{
-          return requests.every(request => {return isValidRequest(request)});
-        }
-      }
-    };
+    // const isValidSession = session => {
+    //   const { sessionName, requests } = session;
+    //   if(!sessionName || !requests){
+    //     throw new Error('sessionName or requests missing');
+    //   }
+    //   else{
+    //     if(!Array.isArray(requests) || requests.length < 1 || typeof sessionName !== 'string'){
+    //       throw new Error('Possible error: \n0.requests is not an array\n1.requests is an empty array\n2.sessionName is not a string');
+    //     }
+    //     else{
+    //       return requests.every(request => {return isValidRequest(request)});
+    //     }
+    //   }
+    // };
+    
     let valid_servers = Array.isArray(opts.servers) && opts.servers.length >= 1 && opts.servers.every(url => isValidUrl(url));;
     let valid_testDuration = Number.isInteger(opts.testDuration) && opts.testDuration >= 1;
     let valid_concurrentUsers = Number.isInteger(opts.concurrentUsers) && opts.concurrentUsers >= 1;
-
-    let valid_sessions = Array.isArray(opts.sessions) && opts.sessions.length >= 1 && opts.sessions.every(session => isValidSession(session));
+    let valid_numOfWorkers = Number.isInteger(opts.numOfWorkers) && opts.numOfWorkers >= 1;
+    let valid_requests = Array.isArray(opts.requests) && opts.requests.length >= 1 && opts.requests.every(request => isValidRequest(request));
 
     if(!valid_servers){
       throw new Error('Invalid servers under config file');
@@ -73,8 +74,11 @@ function validateOpts(opts){
     else if(!valid_concurrentUsers){
       throw new Error('Invalid concurrentUsers under config file, concurrentUsers should be a positive integer');
     }
-    else if(!valid_sessions){
-      throw new Error('Invalid sessions under config file, ');
+    else if(!valid_numOfWorkers){
+      throw new Error('Invalid numOfWorkers under config file, numOfWorkers should be a positive integer');
+    }
+    else if(!valid_requests){
+      throw new Error('Invalid requests under config file, ');
     }
     else{
       return true;

--- a/datafile_bk.json
+++ b/datafile_bk.json
@@ -17,6 +17,18 @@
                 "headers": {
                     "Content-type": "application/json"
                 }
+            },
+            {
+                "requestName": "Login",
+                "url": "/api/login",
+                "method": "POST",
+                "body": {
+                    "username": "testusername",
+                    "password": "testpassword"
+                },
+                "headers": {
+                    "Content-type": "application/json"
+                }
             }
         ],
         "history": [

--- a/dist-electron/child.js
+++ b/dist-electron/child.js
@@ -1,8 +1,7 @@
 const path = require('path')
 const kaskade = require('../kaskade.js');
 
-process.parentPort.on('message', async (e) => {
-  console.log(e.data)
-  const data = await kaskade(path.resolve(__dirname, '../config/example2.json'))
+process.parentPort.on('message', async (opts) => {
+  const data = await kaskade(opts.data)
   process.parentPort.postMessage(data)
 });

--- a/dist-electron/main.js
+++ b/dist-electron/main.js
@@ -11,12 +11,12 @@ function createWindow() {
   electron.ipcMain.handle("read-data-file", () => {
     return fs.readFileSync(path.join(__dirname, "../datafile.json"), "utf8");
   });
-  electron.ipcMain.handle("kaskade-start", async () => {
+  electron.ipcMain.handle("kaskade-start", async (event, opts) => {
     const result = new Promise((resolve, reject) => {
       const child = electron.utilityProcess.fork(path.join(__dirname, "child.js"));
-      child.postMessage({ message: "KASKADE FIRED!" });
+      child.postMessage(opts);
       child.on("message", (data) => {
-        console.log(data);
+        console.log("data in main.js", data);
         resolve(data);
       });
     });

--- a/dist-electron/preload.js
+++ b/dist-electron/preload.js
@@ -8,8 +8,8 @@ electron.contextBridge.exposeInMainWorld("electronAPI", {
   writeDataFile: (content) => {
     return electron.ipcRenderer.send("write-data-file", content);
   },
-  kaskadestart: () => {
-    return electron.ipcRenderer.invoke("kaskade-start");
+  kaskadestart: (opts) => {
+    return electron.ipcRenderer.invoke("kaskade-start", opts);
   }
 });
 function withPrototype(obj) {

--- a/kaskade.js
+++ b/kaskade.js
@@ -5,10 +5,31 @@ const path = require('path');
 const manager = require('./core/manager');
 const validateOpts = require('./core/validateOpts');
 
-async function init(configPath) {
+// async function init(configPath) {
+async function init(opts) {
+  console.log("opts in kaskade.js", opts)
+  
+  // const opts_hardcoded = {
+
+  //   servers: ["localhost:3000"],
+  //   testDuration: 10,
+  //   concurrentUsers: 100,
+  //   targetThroughput: 1000,
+  //   numOfWorkers:100,
+  //   requests: [
+  //     {
+  //         "requestName": "Get all users",
+  //         "url": "/api/getallusers",
+  //         "method": "GET",
+  //         "headers": {
+  //             "Content-type": "application/json"
+  //         }
+  //     }
+  //   ],
+  // }
   try{
-    const configString = fs.readFileSync(configPath);
-    const opts = JSON.parse(configString);
+    // const configString = fs.readFileSync(configPath);
+    // const opts = JSON.parse(configString);
     if(validateOpts(opts)){
       let final_data = await manager(opts)
       return final_data;

--- a/main.js
+++ b/main.js
@@ -16,12 +16,12 @@ function createWindow() {
     return fs.readFileSync(path.join(__dirname, "../datafile.json"), "utf8"); 
   });
 
-  ipcMain.handle('kaskade-start', async () => {
+  ipcMain.handle('kaskade-start', async (event, opts) => {
     const result = new Promise((resolve, reject) => {
       const child = utilityProcess.fork(path.join(__dirname, 'child.js'))
-      child.postMessage({ message: 'KASKADE FIRED!' });
+      child.postMessage(opts);
       child.on('message', (data) => {
-        console.log(data)
+        console.log("data in main.js", data)
         resolve(data);
       })
     });

--- a/preload.js
+++ b/preload.js
@@ -5,7 +5,7 @@ contextBridge.exposeInMainWorld('ipcRenderer', withPrototype(ipcRenderer))
 contextBridge.exposeInMainWorld('electronAPI', {
   readDataFile: () => { return ipcRenderer.invoke('read-data-file'); },
   writeDataFile: (content) => { return ipcRenderer.send('write-data-file', content); },
-  kaskadestart:  () => { return  ipcRenderer.invoke('kaskade-start');}
+  kaskadestart:  (opts) => { return  ipcRenderer.invoke('kaskade-start', opts);}
 })
 
 // `exposeInMainWorld` can't detect attributes and methods of `prototype`, manually patching it.


### PR DESCRIPTION
Test:

1. npm run dev
2. Sessions -> Kaskade TEST1
3. MUST input Test Duration, Concurrent Users, Number of Workers,  Servers is optional (defaulted  to be localhost:3000)
4. hit run
5. Click Result to visualize result

Currently we are reading data from 1st element of datafile.json, all parameters input from frontend simply replace the original data being passed from datafile.json. There is no way to change requests yet (we are still waiting on request builder).

Here is the result:
![Screenshot from 2024-01-27 23-19-58](https://github.com/oslabs-beta/Kaskade/assets/19358126/f35270e3-0409-4d41-b7ac-537d625c7f5a)


**Jingjing and Michael**, please CAREFULLY check runner.js because I got rid of config.sessions according to the most recent format of our datafile.json (we no longer have a property called sessions but instead we have requests).